### PR TITLE
chore: add the type property to the package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "engines": {
     "node": "^18 || ^16 || ^14"
   },
+  "type": "commonjs",
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",
     "test": "npm run test:source && npm run test:types",


### PR DESCRIPTION
From the node.js docs

> Package authors should include the type field, even in packages where all sources are CommonJS. Being explicit about the type of the package will future-proof the package in case the default type of Node.js ever changes, and it will also make things easier for build tools and loaders to determine how the files in the package should be interpreted.

Adding this to all the nodeshift modules