### PR TITLE
fix: add `process.exit(0)` in `ON_DEATH` hook

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -42,6 +42,7 @@ async function runServer(file) {
     }
     ON_DEATH(_ => {
       server.close();
+      process.exit(0);
     });
   } catch (error) {
     console.error(`⛔ ${error}`);


### PR DESCRIPTION
Ensure quick shutdown when browsers are holding open a connection.

Fixes: https://github.com/nodeshift/faas-js-runtime/issues/120