### PR TITLE
chore: Add the node version support to the readme.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   lts:
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -19,21 +19,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npm run build --if-present
-    - run: npm test
-
-  current:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js 18.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 18.x
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  lts:
+  build:
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ be used to declare runtime dependencies for the function. You can also
 provide a path to an arbitrary JavaScript file instead of a directory
 path, allowing you to execute a single file as a function.
 
+|                 | Project Info  |
+| --------------- | ------------- |
+| License:        | Apache-2.0  |
+| Issue tracker:  | https://github.com/nodeshift/faas-js-runtime/issues  |
+| Engines:        | Node.js >= 14 |
+
 The function is loaded and then invoked for incoming HTTP requests
 at `localhost:8080`. The incoming request may be a
 [Cloud Event](https://github.com/cloudevents/sdk-javascript#readme.) or


### PR DESCRIPTION
This also adds Node 18 to the lts section of the ci workflow as well as removing the 'current' section.

fixes #124