### PR TITLE
chore: update the publish token name for npm

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -29,5 +29,5 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.FAAS_JS_RUNTIME_PUBLISH}}
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
After moving to nodeshift, the existing token was deleted from npm and a new token was created with more limited publish permissions - only able to publish this repo. The name was changed to FAAS_JS_RUNTIME_PUBLISH.

/cc @lholmquist 