### PR TITLE
chore: add the node version to the logger output

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,18 @@ function start(func, options) {
 
   // Create the server
   const { logLevel = LOG_LEVEL, port = PORT } = { ...options };
-  const server = fastify({ logger: { level: logLevel } });
+  const server = fastify({
+    logger: {
+      level: logLevel,
+      formatters: {
+        bindings: bindings => ({
+            pid: bindings.pid,
+            hostname: bindings.hostname,
+            node_version: process.version
+        })
+      }
+    }
+  });
 
   server.addContentTypeParser('application/x-www-form-urlencoded',
     function(_, payload, done) {


### PR DESCRIPTION
This adds a `node_version` parameter to the logger output, which would make the log look like this:

```
{"level":30,"time":1678805584609,"pid":14210,"hostname":"lholmqui-mac","node_version":"v18.13.0","reqId":"req-1","res":{"statusCode":204},"responseTime":0.304443359375,"msg":"request completed"}
```

I thought it might be nice to have this to easily identify the node version someone is using, if they have errors