### PR TITLE
feat: add lifecycle and endpoint customization

### DIFF
--- a/lib/health-check.js
+++ b/lib/health-check.js
@@ -23,8 +23,11 @@ function callProtect(request, reply) {
   protect(request, reply, _ => reply.send('OK'));
 }
 
-module.exports = function use(fastify, _, done) {
-  fastify.get(readinessURL, { logLevel: 'warn' }, callProtect);
-  fastify.get(livenessURL, { logLevel: 'warn' }, callProtect);
-  done();
+module.exports = function healthCheck(opts) {
+  return (fastify, _, done) => {
+    // Handle health checks
+    fastify.get(opts?.readiness?.path || readinessURL, { logLevel: 'warn' }, opts.readiness || callProtect);
+    fastify.get(opts?.liveness?.path || livenessURL, { logLevel: 'warn' }, opts.liveness || callProtect);
+    done();
+  };
 };

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -30,7 +30,7 @@ module.exports = function use(server, opts) {
 
   // Handle health checks
   server.register(function healthCheckContext(s, _, done) {
-    s.register(healthCheck);
+    s.register(healthCheck(opts.funcConfig));
     done();
   });
 };

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,6 +1,15 @@
 /* eslint-disable no-unused-vars */
 import { IncomingHttpHeaders, IncomingMessage } from 'http';
 import { CloudEvent } from 'cloudevents';
+import { Http2ServerRequest, Http2ServerResponse } from 'http2';
+
+export interface Function {
+  init: () => any;
+  shutdown: () => any;
+  liveness: (request: Http2ServerRequest, reply: Http2ServerResponse) => any;
+  readiness: (request: Http2ServerRequest, reply: Http2ServerResponse) => any;
+  handle: CloudEventFunction | HTTPFunction;
+}
 
 /**
  * CloudEventFunction describes the function signature for a function that accepts CloudEvents.


### PR DESCRIPTION
This is still a work in progress. Enables function developers to export `init()`, `shutdown()`, `liveness()` and `readiness()` functions from the function file, enabling startup behaviors such as a connection to a database or other persistent store, clean shutdowns, and customizable liveness and readiness checks.

Fixes: https://github.com/nodeshift/faas-js-runtime/issues/142