### PR TITLE
chore: move publish to its own workflow and add sigstore provenance

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -15,19 +15,3 @@ jobs:
           bump-minor-pre-major: "true"
           package-name: faas-js-runtime
           changelog-types: '[{"type":"enhancement","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false},{"type":"cleanup","section":"Miscellaneous","hidden":false},{"type":"api-change","section":"API Changes","hidden":false},{"type":"documentation","section":"Documentation","hidden":false},{"type":"techdebt","section":"Miscellaneous","hidden":false},{"type":"proposal","section":"Miscellaneous","hidden":false},{"type":"feat","section":"Features","hidden":false}]'
-
-      - uses: actions/checkout@v3
-        if: ${{ steps.release.outputs.release_created }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          registry-url: 'https://registry.npmjs.org'
-        if: ${{ steps.release.outputs.release_created }}
-      - run: npm ci
-        if: ${{ steps.release.outputs.release_created }}
-      - run: npm test
-        if: ${{ steps.release.outputs.release_created }}
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.FAAS_JS_RUNTIME_PUBLISH}}
-        if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+name: Publish to npmjs
+on:
+ release:
+   types: [created]
+jobs:
+ build:
+   runs-on: ubuntu-latest
+   permissions:
+     contents: read
+     id-token: write
+   steps:
+     - uses: actions/checkout@v3
+     - uses: actions/setup-node@v3
+       with:
+         node-version: '18.x'
+         registry-url: 'https://registry.npmjs.org'
+     - run: npm install -g npm
+     - run: npm ci
+     - run: npm publish --provenance --access public
+       env:
+         NODE_AUTH_TOKEN: ${{ secrets.FAAS_JS_RUNTIME_PUBLISH }}


### PR DESCRIPTION
This pulls the actual publication of the module into its own workflow, which is run when a release is created. It also adds sigstore provenance to the publication so that the release is signed by sigstore and logged in a public transparency ledger.

See: https://docs.npmjs.com/generating-provenance-statements
See: https://www.sigstore.dev/