### PR TITLE
chore: change sbom generation to happen on `prepublishOnly`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:source": "nyc --reporter=lcovonly tape test/test*.js | colortape",
     "test:types": "tsd",
     "pretest": "npm run lint",
-    "postinstall": "npx @cyclonedx/cyclonedx-npm --omit dev --package-lock-only --output-file sbom.json"
+    "sbom": "npx @cyclonedx/cyclonedx-npm --omit dev --package-lock-only --output-file sbom.json",
+    "prepublishOnly": "npm run sbom && git diff-files --quiet"
   },
   "description": "A Node.js framework for executing arbitrary functions in response to HTTP or cloud events",
   "files": [

--- a/sbom.json
+++ b/sbom.json
@@ -3,9 +3,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:ed7e6bd5-f552-401a-ae15-05f899c57933",
+  "serialNumber": "urn:uuid:1a3adee4-7f98-4b19-8c50-97eda0e1d650",
   "metadata": {
-    "timestamp": "2023-07-10T20:34:21.993Z",
+    "timestamp": "2023-07-13T21:02:27.796Z",
     "tools": [
       {
         "vendor": "@cyclonedx",
@@ -55,8 +55,8 @@
     "component": {
       "type": "application",
       "name": "faas-js-runtime",
-      "version": "2.1.2",
-      "bom-ref": "faas-js-runtime@2.1.2",
+      "version": "2.2.0",
+      "bom-ref": "faas-js-runtime@2.2.0",
       "author": "Red Hat, Inc.",
       "description": "A Node.js framework for executing arbitrary functions in response to HTTP or cloud events",
       "licenses": [
@@ -66,7 +66,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/faas-js-runtime@2.1.2?vcs_url=git%2Bhttps%3A//github.com/nodeshift/faas-js-runtime.git",
+      "purl": "pkg:npm/faas-js-runtime@2.2.0?vcs_url=git%2Bhttps%3A//github.com/nodeshift/faas-js-runtime.git",
       "externalReferences": [
         {
           "url": "git+https://github.com/nodeshift/faas-js-runtime.git",
@@ -2764,7 +2764,7 @@
   ],
   "dependencies": [
     {
-      "ref": "faas-js-runtime@2.1.2",
+      "ref": "faas-js-runtime@2.2.0",
       "dependsOn": [
         "cloudevents@7.0.1",
         "commander@11.0.0",


### PR DESCRIPTION
By having the sbom generated during the `postinstall` step, we have inadvertently made the package impossible to install as a dependency. This is because when installing this as a dependency in a project, `npm install` is run under the hood. Subsequently, `npm run postinstall` happens, but the published package does not contain a package-lock.json file and the sbom generation fails, therefore failing the installation of the module altogether.

This commit modifies the npm scripts so that the sbom generation happens only when publishing, and the publish will fail if there are any modified files in the repo, i.e. if the sbom was updated. This means it is incumbent on maintainers of this package to keep the sbom up to date by periodically running `npm run sbom` when modifying dependencies. If in the course of making changes on this module, the package.json or package-lock.json files are modified, the developer MUST run the command `npm run sbom`.