### PR TITLE
fix: temporarily removes the prePublish step allowing us to publish a new version and for users to use this module.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "faas-js-runtime",
       "version": "2.2.1",
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "cloudevents": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "test:source": "nyc --reporter=lcovonly tape test/test*.js | colortape",
     "test:types": "tsd",
     "pretest": "npm run lint",
-    "sbom": "npx @cyclonedx/cyclonedx-npm --omit dev --package-lock-only --output-file sbom.json",
-    "prepublishOnly": "npm run sbom && git diff-files --quiet"
+    "sbom": "npx @cyclonedx/cyclonedx-npm --omit dev --package-lock-only --output-file sbom.json"
   },
   "description": "A Node.js framework for executing arbitrary functions in response to HTTP or cloud events",
   "files": [

--- a/sbom.json
+++ b/sbom.json
@@ -3,9 +3,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:1a3adee4-7f98-4b19-8c50-97eda0e1d650",
+  "serialNumber": "urn:uuid:cce19171-5848-423d-bacb-7ba3554999e5",
   "metadata": {
-    "timestamp": "2023-07-13T21:02:27.796Z",
+    "timestamp": "2023-07-14T13:29:06.080Z",
     "tools": [
       {
         "vendor": "@cyclonedx",
@@ -55,8 +55,8 @@
     "component": {
       "type": "application",
       "name": "faas-js-runtime",
-      "version": "2.2.0",
-      "bom-ref": "faas-js-runtime@2.2.0",
+      "version": "2.2.1",
+      "bom-ref": "faas-js-runtime@2.2.1",
       "author": "Red Hat, Inc.",
       "description": "A Node.js framework for executing arbitrary functions in response to HTTP or cloud events",
       "licenses": [
@@ -66,7 +66,7 @@
           }
         }
       ],
-      "purl": "pkg:npm/faas-js-runtime@2.2.0?vcs_url=git%2Bhttps%3A//github.com/nodeshift/faas-js-runtime.git",
+      "purl": "pkg:npm/faas-js-runtime@2.2.1?vcs_url=git%2Bhttps%3A//github.com/nodeshift/faas-js-runtime.git",
       "externalReferences": [
         {
           "url": "git+https://github.com/nodeshift/faas-js-runtime.git",
@@ -2764,7 +2764,7 @@
   ],
   "dependencies": [
     {
-      "ref": "faas-js-runtime@2.2.0",
+      "ref": "faas-js-runtime@2.2.1",
       "dependsOn": [
         "cloudevents@7.0.1",
         "commander@11.0.0",


### PR DESCRIPTION


@lance i "borrowed" this from your release-please issue :) 

The Context:

When the release PR is merged, this includes changes to the package-lock.json file which in turn results in a modification of the SBOM, which means that when the release is published, the SBOM is out of date.

A tangible example:

clone this repository: https://github.com/nodeshift/faas-js-runtime change into the repo directory and run git checkout v2.2.1 (the most recent release tag) run npm run sbom which generates an SBOM based on the current package-lock.json file run git diff to see what should have been included in the release SBOM