### PR TITLE
Enable OPTIONS preflight and a method to enable cros origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ export interface Function {
   // This function is optional and should be synchronous.
   shutdown?: () => any;
 
+  // Function that returns an array of CORS origins
+  // This function is optional.
+  cors?: () => string[];
+
   // The liveness function, called to check if the server is alive
   // This function is optional and should return 200/OK if the server is alive.
   liveness?: HealthCheck;

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const INCLUDE_RAW = false;
 
 /**
  * Starts the provided Function. If the function is a module, it will be
- * inspected for init, shutdown, liveness, and readiness functions and those
+ * inspected for init, shutdown, cors, liveness, and readiness functions and those
  * will be used to configure the server. If it's a function, it will be used
  * directly.
  *
@@ -55,6 +55,9 @@ async function start(func, options) {
   }
   if (typeof func.readiness === 'function') {
     options.readiness = func.readiness;
+  }
+  if (typeof func.cors === 'function') {
+    options.cors = func.cors;
   }
   return __start(func.handle, options);
 }
@@ -136,7 +139,7 @@ function initializeServer(config) {
   // Add a parser for application/x-www-form-urlencoded
   server.addContentTypeParser(
     'application/x-www-form-urlencoded',
-    function(_, payload, done) {
+    function (_, payload, done) {
       var body = '';
       payload.on('data', data => (body += data));
       payload.on('end', _ => {
@@ -156,7 +159,7 @@ function initializeServer(config) {
   server.addContentTypeParser(
     '*',
     { parseAs: 'buffer' },
-    function(req, body, done) {
+    function (req, body, done) {
       try {
         done(null, body);
       } catch (err) {

--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ function initializeServer(config) {
   // Add a parser for application/x-www-form-urlencoded
   server.addContentTypeParser(
     'application/x-www-form-urlencoded',
-    function (_, payload, done) {
+    function(_, payload, done) {
       var body = '';
       payload.on('data', data => (body += data));
       payload.on('end', _ => {
@@ -159,7 +159,7 @@ function initializeServer(config) {
   server.addContentTypeParser(
     '*',
     { parseAs: 'buffer' },
-    function (req, body, done) {
+    function(req, body, done) {
       try {
         done(null, body);
       } catch (err) {

--- a/lib/invocation-handler.js
+++ b/lib/invocation-handler.js
@@ -20,7 +20,7 @@ module.exports = function use(fastify, opts, done) {
   async function doOptions(_request, reply) {
     reply.code(204).headers({
       'content-type': 'application/json; charset=utf-8',
-      'access-control-allow-methods': 'OPTIONS, GET, POST',
+      'access-control-allow-methods': 'OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH',
       'access-control-allow-origin': '*',
       'access-control-allow-headers': '*'
     }).send();

--- a/lib/invocation-handler.js
+++ b/lib/invocation-handler.js
@@ -22,6 +22,7 @@ module.exports = function use(fastify, opts, done) {
       'content-type': 'application/json; charset=utf-8',
       'access-control-allow-methods': 'OPTIONS, GET, POST',
       'access-control-allow-origin': '*',
+      'access-control-allow-headers': '*'
     }).send();
   }
   done();

--- a/lib/invocation-handler.js
+++ b/lib/invocation-handler.js
@@ -4,7 +4,8 @@ const invoker = require('./invoker');
 module.exports = function use(fastify, opts, done) {
   fastify.get('/', doGet);
   fastify.post('/', doPost);
-  const invokeFunction = invoker(opts.func);
+  fastify.options('/', doOptions);
+  const invokeFunction = invoker(opts);
 
   // TODO: if we know this is a CloudEvent function, should
   // we allow GET requests?
@@ -14,6 +15,14 @@ module.exports = function use(fastify, opts, done) {
 
   async function doPost(request, reply) {
     sendReply(reply, await invokeFunction(request.fcontext, reply.log));
+  }
+
+  async function doOptions(_request, reply) {
+    reply.code(204).headers({
+      'content-type': 'application/json; charset=utf-8',
+      'access-control-allow-methods': 'OPTIONS, GET, POST',
+      'access-control-allow-origin': '*',
+    }).send();
   }
   done();
 };

--- a/lib/invoker.js
+++ b/lib/invoker.js
@@ -3,7 +3,8 @@
  */
 const { CloudEvent, HTTP } = require('cloudevents');
 
-module.exports = function invoker(func) {
+module.exports = function invoker(opts) {
+  const func = opts.func;
   return async function invokeFunction(context, log) {
     // Default payload values
     const payload = {
@@ -11,11 +12,18 @@ module.exports = function invoker(func) {
       response: undefined,
       headers: {
         'content-type': 'application/json; charset=utf-8',
-        'access-control-allow-methods':
-          'OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH',
-        'access-control-allow-origin': '*'
+        'access-control-allow-methods': 'OPTIONS, GET, POST',
       }
     };
+
+    if (opts.funcConfig.cors) {
+      const allowedOrigins = opts.funcConfig.cors();
+      const requestOrigin = context.headers.origin;
+      const originIncluded = allowedOrigins.includes(requestOrigin) ? requestOrigin : null;
+      payload.headers['access-control-allow-origin'] = originIncluded;
+    } else {
+      payload.headers['access-control-allow-origin'] = '*';
+    }
 
     let fnReturn;
     const scope = Object.freeze({});
@@ -29,7 +37,7 @@ module.exports = function invoker(func) {
         if (fnReturn instanceof CloudEvent || fnReturn.constructor?.name === 'CloudEvent') {
           try {
             const message = HTTP.binary(fnReturn);
-            payload.headers = {...payload.headers, ...message.headers};
+            payload.headers = { ...payload.headers, ...message.headers };
             payload.response = message.body;
             // In this case, where the function is invoked with a CloudEvent
             // and returns a CloudEvent we don't need to continue processing the

--- a/lib/invoker.js
+++ b/lib/invoker.js
@@ -12,7 +12,7 @@ module.exports = function invoker(opts) {
       response: undefined,
       headers: {
         'content-type': 'application/json; charset=utf-8',
-        'access-control-allow-methods': 'OPTIONS, GET, POST',
+        'access-control-allow-methods': 'OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH',
       }
     };
 

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -61,7 +61,7 @@ export enum LogLevel {
 /**
  * CloudEventFunction describes the function signature for a function that accepts CloudEvents.
  */
-export interface CloudEventFunction<I = never, R = unknown> {
+export interface CloudEventFunction<I=never, R=unknown> {
   (context: Context, event?: CloudEvent<I>): CloudEventFunctionReturn<R>;
 }
 
@@ -97,33 +97,33 @@ export type ResponseBody = string | object | Buffer;
 
 // Context is the request context for HTTP and CloudEvent functions.
 export interface Context {
-  log: Logger;
-  req: IncomingMessage;
-  query?: Record<string, any>;
-  body?: Record<string, any> | string;
-  rawBody?: string;
-  method: string;
-  headers: IncomingHttpHeaders;
-  httpVersion: string;
-  httpVersionMajor: number;
-  httpVersionMinor: number;
-  cloudevent: CloudEvent<unknown>;
-  cloudEventResponse(data: string | object): CloudEventResponse;
+    log: Logger;
+    req: IncomingMessage;
+    query?: Record<string, any>;
+    body?: Record<string, any>|string;
+    rawBody?: string;
+    method: string;
+    headers: IncomingHttpHeaders;
+    httpVersion: string;
+    httpVersionMajor: number;
+    httpVersionMinor: number;
+    cloudevent: CloudEvent<unknown>;
+    cloudEventResponse(data: string|object): CloudEventResponse;
 }
 
 export interface Logger {
-  debug: (msg: any) => void,
-  info:  (msg: any) => void,
-  warn:  (msg: any) => void,
-  error: (msg: any) => void,
-  fatal: (msg: any) => void,
-  trace: (msg: any) => void,
+    debug: (msg: any) => void,
+    info:  (msg: any) => void,
+    warn:  (msg: any) => void,
+    error: (msg: any) => void,
+    fatal: (msg: any) => void,
+    trace: (msg: any) => void,
 }
 
 export interface CloudEventResponse {
-  id(id: string): CloudEventResponse;
-  source(source: string): CloudEventResponse;
-  type(type: string): CloudEventResponse;
-  version(version: string): CloudEventResponse;
-  response(): CloudEvent;
+    id(id: string): CloudEventResponse;
+    source(source: string): CloudEventResponse;
+    type(type: string): CloudEventResponse;
+    version(version: string): CloudEventResponse;
+    response(): CloudEvent;
 }

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
-import { IncomingHttpHeaders, IncomingMessage } from 'http';
 import { CloudEvent } from 'cloudevents';
+import { IncomingHttpHeaders, IncomingMessage } from 'http';
 import { Http2ServerRequest, Http2ServerResponse } from 'http2';
 
 /**
@@ -112,12 +112,12 @@ export interface Context {
 }
 
 export interface Logger {
-    debug: (msg: any) => void,
-    info:  (msg: any) => void,
-    warn:  (msg: any) => void,
-    error: (msg: any) => void,
-    fatal: (msg: any) => void,
-    trace: (msg: any) => void,
+  debug: (msg: any) => void,
+  info:  (msg: any) => void,
+  warn:  (msg: any) => void,
+  error: (msg: any) => void,
+  fatal: (msg: any) => void,
+  trace: (msg: any) => void,
 }
 
 export interface CloudEventResponse {

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -16,6 +16,10 @@ export interface Function {
   // This function is optional.
   shutdown?: () => (any | Promise<any>);
 
+  // Function that returns an array of CORS origins
+  // This function is optional.
+  cors?: () => string[];
+
   // The liveness function, called to check if the server is alive
   // This function is optional and should return 200/OK if the server is alive.
   liveness?: HealthCheck;
@@ -57,7 +61,7 @@ export enum LogLevel {
 /**
  * CloudEventFunction describes the function signature for a function that accepts CloudEvents.
  */
-export interface CloudEventFunction<I=never, R=unknown> {
+export interface CloudEventFunction<I = never, R = unknown> {
   (context: Context, event?: CloudEvent<I>): CloudEventFunctionReturn<R>;
 }
 
@@ -93,18 +97,18 @@ export type ResponseBody = string | object | Buffer;
 
 // Context is the request context for HTTP and CloudEvent functions.
 export interface Context {
-    log: Logger;
-    req: IncomingMessage;
-    query?: Record<string, any>;
-    body?: Record<string, any>|string;
-    rawBody?: string;
-    method: string;
-    headers: IncomingHttpHeaders;
-    httpVersion: string;
-    httpVersionMajor: number;
-    httpVersionMinor: number;
-    cloudevent: CloudEvent<unknown>;
-    cloudEventResponse(data: string|object): CloudEventResponse;
+  log: Logger;
+  req: IncomingMessage;
+  query?: Record<string, any>;
+  body?: Record<string, any> | string;
+  rawBody?: string;
+  method: string;
+  headers: IncomingHttpHeaders;
+  httpVersion: string;
+  httpVersionMajor: number;
+  httpVersionMinor: number;
+  cloudevent: CloudEvent<unknown>;
+  cloudEventResponse(data: string | object): CloudEventResponse;
 }
 
 export interface Logger {
@@ -117,9 +121,9 @@ export interface Logger {
 }
 
 export interface CloudEventResponse {
-    id(id: string): CloudEventResponse;
-    source(source: string): CloudEventResponse;
-    type(type: string): CloudEventResponse;
-    version(version: string): CloudEventResponse;
-    response(): CloudEvent;
+  id(id: string): CloudEventResponse;
+  source(source: string): CloudEventResponse;
+  type(type: string): CloudEventResponse;
+  version(version: string): CloudEventResponse;
+  response(): CloudEvent;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -378,6 +378,45 @@ test('Sends CORS headers in HTTP response', t => {
       }, errHandler(t));
 });
 
+test('Responds to OPTIONS with CORS headers in HTTP response', t => {
+  start(_ => '')
+    .then(server => {
+      t.plan(2);
+      request(server)
+        .options('/')
+        .expect(204)
+        .expect('Access-Control-Allow-Origin', '*')
+        .expect('Access-Control-Allow-Methods',
+          'OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH')
+        .end((err, res) => {
+          t.error(err, 'No error');
+          t.equal(res.text, '');
+          t.end();
+          server.close();
+        });
+      }, errHandler(t));
+});
+
+test('Responds to GET with CORS headers in HTTP response', t => {
+  start(_ => '', {  cors: () => ['http://example.com', 'http://example2.com'] } )
+    .then(server => {
+      t.plan(2);
+      request(server)
+        .get('/')
+        .expect(204)
+        .set('Origin', 'http://example.com')
+        .expect('Access-Control-Allow-Origin', 'http://example.com')
+        .expect('Access-Control-Allow-Methods',
+          'OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH')
+        .end((err, res) => {
+          t.error(err, 'No error');
+          t.equal(res.text, '');
+          t.end();
+          server.close();
+        });
+      }, errHandler(t));
+});
+
 test('Respects headers set by the function', t => {
   const func = require(`${__dirname}/fixtures/response-header/`);
   start(func)


### PR DESCRIPTION
**Reasoning**
- At the moment, no support for OPTIONS request is implemented. This is the preflight request for CORS checks, thus API calls to a serverless function from a web browser is failing.

**Changes**
- Enable preflight response **[OPTIONS]** with generic cors allow.
- Export a function "cors" where you can specify the allowed origins.